### PR TITLE
[REFACTOR] May31_2: readlines() -> input()

### DIFF
--- a/May31_2.py
+++ b/May31_2.py
@@ -1,24 +1,11 @@
 import sys
-
 sys.stdin = open("in1.txt", "rt")
-the_whole_input = sys.stdin
-i_lines = the_whole_input.readlines()
-testcase_cnt = int(i_lines[0])
 
-sys.stdin = open("out1.txt", "rt")
-the_whole_output = sys.stdin
-o_lines = the_whole_output.readlines()
+text_by_line = int(input())
 
-cnt = 1
-for i in range(testcase_cnt):
-    n, s, e, k = map(int, i_lines[2*cnt-1].split(sep=' '))
-    i_lines_list = i_lines[2*cnt].strip().split(' ')
-    i_lines_int_list = list(map(int, i_lines_list))[s-1:e]
-    output = sorted(i_lines_int_list)[k-1]
-
-    if int(output) == int(o_lines[cnt-1].split(' ')[1]):
-        print('정답')
-    else:
-        print('돌아가')
-
-    cnt += 1
+for i in range(text_by_line):
+    n, s, e, k = map(int, input().split())
+    a = list(map(int, input().split()[s-1:e]))
+    a.sort()
+    print(a[k-1])
+    print(f'#{i+1} {a[k-1]}')


### PR DESCRIPTION
- theo님 커멘트 반영
- input()
Read a string **from standard input**. **The trailing newline is stripped**.
The prompt string, if given, **is printed to standard output without a trailing newline before reading input**.
If the user hits EOF (*nix: Ctrl-D, Windows: Ctrl-Z+Return), raise EOFError. On *nix systems, readline is used if available.


